### PR TITLE
Make Int cardinality bit-width aware

### DIFF
--- a/src/Cantor.hs
+++ b/src/Cantor.hs
@@ -64,6 +64,7 @@ import Data.Functor.Const
 import Data.Proxy
 import Math.NumberTheory.Powers.Squares (integerSquareRoot')
 import Data.Void
+import Data.Bits (finiteBitSize)
 import qualified Data.Map as M
 
 
@@ -218,7 +219,7 @@ instance Cantor Int64 where
 
 instance Finite Int
 instance Cantor Int where
-  cardinality = Finite $ 2 ^ (64 :: Integer)
+  cardinality = Finite $ 2 ^ (finiteBitSize @Int undefined)
   toCantor = fromInteger . toCantor @Integer
   fromCantor = fromCantor @Integer . toInteger
 


### PR DESCRIPTION
The current implementation is incorrect on 32-bit platforms. This should be correct on both 32-bit and 64-bit.

note: untested on 32-bit.